### PR TITLE
Add ltsv parser mode

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,7 +7,7 @@ RUN apk --update add tzdata && \
     cp /usr/share/zoneinfo/Asia/Tokyo /etc/localtime && \
     echo Asia/Tokyo > /etc/timezone && \
     rm -rf /var/cache/apk/*
-RUN pip3 install ipaddress requests numpy asciimatics nuitka
+RUN pip3 install ipaddress requests numpy asciimatics ltsv apache-log-parser nuitka
 
 RUN mkdir /app
 WORKDIR /app


### PR DESCRIPTION
## 目的

- CLF形式とLTSV形式両方に対応

## 変更のポイント

- LTSV形式は`ltsv`でパース
- CLF形式は`apache_log_parser`でパース
- CLF形式についてはパースフォーマットを引数`-c`で指定可能に変更
- `Dockerfile`も併せて修正
- 各パーサーの内部日付パース処理がおそすぎるので `isostrptime` で高速化

## 既知の制約

- パーサーがログの各行に対してパース処理を行う都合で速度低下が発生
