### PR TITLE
Fix/install scipy

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,7 +9,7 @@ RUN apk --update add tzdata && \
     cp /usr/share/zoneinfo/Asia/Tokyo /etc/localtime && \
     echo Asia/Tokyo > /etc/timezone && \
     rm -rf /var/cache/apk/*
-RUN pip3 install six packaging ipaddress requests numpy asciimatics ltsv apache-log-parser dnspython
+RUN pip3 install six packaging ipaddress requests numpy scipy asciimatics ltsv apache-log-parser dnspython
 
 RUN mkdir /app
 WORKDIR /app

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,15 +1,24 @@
-FROM nerdwaller/pyinstaller-alpine:py3 as build
+FROM python:3.6-alpine3.7 as build
 
 ENV LANG C.UTF-8
 
 RUN apk update && apk upgrade && \
-    apk add --no-cache git gzip gfortran musl-dev gcc libc-dev zlib-dev jpeg-dev && \
+    apk add --no-cache git gzip gfortran musl-dev gcc make g++ file libc-dev zlib-dev jpeg-dev lapack-dev && \
     pip3 install --upgrade pip
 RUN apk --update add tzdata && \
     cp /usr/share/zoneinfo/Asia/Tokyo /etc/localtime && \
     echo Asia/Tokyo > /etc/timezone && \
     rm -rf /var/cache/apk/*
-RUN pip3 install six packaging ipaddress requests numpy scipy asciimatics ltsv apache-log-parser dnspython
+
+# Build bootloader for alpine
+RUN git clone https://github.com/pyinstaller/pyinstaller.git /tmp/pyinstaller \
+    && cd /tmp/pyinstaller/bootloader \
+    && python ./waf configure --no-lsb all \
+    && pip install .. \
+    && rm -Rf /tmp/pyinstaller
+
+RUN pip3 install six packaging ipaddress requests numpy asciimatics ltsv apache-log-parser dnspython
+RUN pip3 install scipy
 
 RUN mkdir /app
 WORKDIR /app
@@ -22,7 +31,7 @@ RUN cd /app && pyinstaller --hidden-import six \
     --hidden-import packaging.requirements \
     --clean --strip --noconfirm --onefile -n tip trend_of_ip.py
 
-FROM alpine:3.5
+FROM alpine:3.7
 
 RUN apk update && apk upgrade && apk --update add tzdata && \
     cp /usr/share/zoneinfo/Asia/Tokyo /etc/localtime && \


### PR DESCRIPTION
## 目的

- `scipy` の docker buildにコケるので修正

## 修正のポイント

- `lapack-dev` が必要だけど `nerdwaller/pyinstaller-alpine:py3` が alpine3.4ベースでできてて alpine3.5じゃないと`lapack-dev`が無いので諦めて pyinstallerのbuildも含めて alpine3.7ベースに変更
- `pip install numpy scipy`するとうまく`scipy`が入らないので`RUN`分けて対応
