### PR TITLE
Feature/binary for amazon linux

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,3 +1,9 @@
+#
+# Build with:
+# docker build --target build -t tsutorm/trend_of_ip-build:alpine .
+# docker build -t tsutorm/trend_of_ip .
+#
+
 FROM python:3.6-alpine3.7 as build
 
 ENV LANG C.UTF-8

--- a/builds/alpine/Dockerfile
+++ b/builds/alpine/Dockerfile
@@ -1,7 +1,7 @@
 #
 # Build with:
-# docker build --target build -t tsutorm/trend_of_ip-build:alpine .
-# docker build -t tsutorm/trend_of_ip .
+# docker build --compress	--target build -t tsutorm/trend_of_ip-build:alpine .
+# docker build --compress	-t tsutorm/trend_of_ip .
 #
 
 FROM python:3.6-alpine3.7 as build

--- a/builds/aws/Dockerfile
+++ b/builds/aws/Dockerfile
@@ -1,0 +1,56 @@
+#
+# Build with:
+# docker build --compress	--target build -t tsutorm/trend_of_ip-build:aws .
+#
+# docker run  --name trend_of_ip-build-aws -it tsutorm/trend_of_ip-build:aws /app/dist/tip -h
+# docker cp trend_of_ip-build-aws:/app/dist/tip dist/tip.aws
+#
+
+FROM amazonlinux:2018.03 as build
+
+ENV LANG en_US.UTF-8
+ENV PYSHORT 3.6
+ENV PYTHONVER 3.6.1
+
+RUN yum -y update && \
+    yum groupinstall -y "Development tools" && yum groupinstall -y "Development Libraries" && \
+    yum install -y zlib-devel bzip2-devel openssl-devel ncurses-devel readline-devel tk-devel lapack-devel atlas-devel \
+        libpcap-devel xz-devel libjpeg-devel wget git
+
+WORKDIR /tmp
+
+RUN wget --no-check-certificate https://www.python.org/ftp/python/${PYTHONVER}/Python-${PYTHONVER}.tgz
+RUN tar -zxvf Python-${PYTHONVER}.tgz
+
+WORKDIR /tmp/Python-${PYTHONVER}
+RUN ./configure --prefix=/usr/local LDFLAGS="-Wl,-rpath /usr/local/lib" --with-ensurepip=install --enable-shared
+RUN make && make altinstall
+RUN rm -r /tmp/Python-${PYTHONVER}
+RUN ln -sf /usr/local/bin/python3.6 /usr/bin/python3 && \
+    ln -sf /usr/local/bin/pip3.6 /usr/bin/pip3 && \
+    pip3 install --upgrade pip setuptools
+RUN pip3 install six pycrypto packaging ipaddress requests numpy asciimatics ltsv apache-log-parser dnspython
+RUN pip3 install scipy
+RUN pip3 install pyinstaller
+
+RUN mkdir /app
+WORKDIR /app
+ADD . /app
+
+RUN cd /app && pyinstaller --hidden-import six \
+    --hidden-import packaging \
+    --hidden-import packaging.version \
+    --hidden-import packaging.specifiers \
+    --hidden-import packaging.requirements \
+    --hidden-import tkinter \
+    --strip --noconfirm --onefile --clean -n tip trend_of_ip.py
+
+FROM amazonlinux:2018.03
+
+RUN yum -y update
+
+WORKDIR /app
+
+COPY --from=build /app/dist/tip /app/dist/tip
+
+ENTRYPOINT ["/app/dist/tip"]

--- a/scripts/build-dist.sh
+++ b/scripts/build-dist.sh
@@ -1,0 +1,35 @@
+#!/bin/bash
+
+set -eu
+
+
+CWD="$(dirname "$0")/.."
+cd $CWD
+
+packageBinary() {
+  ARCH=${1:-aws}
+
+  BUILD_NAME=tip
+  PACKAGE_PATH=$CWD/dist/
+  DOCKER_IMAGE="trend_of_ip-build-for-$ARCH"
+  ZIP_NAME="$BUILD_NAME-for-$ARCH.zip"
+
+  rm -Rf $PACKAGE_PATH
+  mkdir -p $PACKAGE_PATH
+
+  docker build -f builds/$ARCH/Dockerfile --compress --target build -t tsutorm/$DOCKER_IMAGE .
+  docker run  --name $DOCKER_IMAGE -it tsutorm/$DOCKER_IMAGE /app/dist/tip -h
+  docker cp $DOCKER_IMAGE:/app/dist/tip $PACKAGE_PATH
+  docker rm $DOCKER_IMAGE
+
+  # Package
+  zip -9 -D "$PACKAGE_PATH$ZIP_NAME" "$PACKAGE_PATH$BUILD_NAME"
+
+  echo "done."
+}
+
+if [ ! -z "$1" ]; then
+  packageBinary "$1"
+else
+  packageBinary aws
+fi


### PR DESCRIPTION
## 目的

- Amazon Linux(1)用のビルドバイナリを配布するためのDockerfileとスクリプトを追加

## みどころ

- `scripts/build-dist.sh` を追加。実行すると `dist/tip-for-aws.zip` ができる